### PR TITLE
v2.1

### DIFF
--- a/tpIpfTool/IpfPack.cs
+++ b/tpIpfTool/IpfPack.cs
@@ -16,12 +16,14 @@ namespace tpIpfTool {
 			Print = dlg;
 		}
 
+        string ipfTgtName = null;
 
-		public int PacIpf(string[] files, uint tgtver, uint pkgver) {
+		public int PacIpf(string[] files, uint tgtver, uint pkgver ,string tgtName) {
 			try {
 				ipfTgtVer = tgtver;
 				ipfPkgVer = pkgver;
-				lstFileTab.Clear();
+                ipfTgtName = tgtName;
+                lstFileTab.Clear();
 				foreach (var x in files) {
 					string dPath = Path.GetFullPath(x+"\\");
 					var dFiles = Directory.EnumerateFiles(dPath, "*", SearchOption.AllDirectories);
@@ -45,19 +47,20 @@ namespace tpIpfTool {
 			}
 			return -9999;
 		}
-		public int PacAddon(string[] files, uint tgtver, uint pkgver) {
+		public int PacAddon(string[] files, uint tgtver, uint pkgver,string tgtName) {
 			try {
 				ipfTgtVer = tgtver;
 				ipfPkgVer = pkgver;
+                ipfTgtName = tgtName;
 				lstFileTab.Clear();
 				foreach (var x in files) {
 					string dPath = Path.GetDirectoryName(x)+"\\";
 					var dFiles = Directory.EnumerateFiles(x, "*", SearchOption.AllDirectories);
-					foreach (var fPath in dFiles) {
+                    foreach (var fPath in dFiles) {
 						var fti=new FileTableInf();
 						fti.filePath = fPath;
-						fti.archNm = "addon_d.ipf";
-						fti.fileNm = fPath.Remove(0, dPath.Length).Replace("\\","/");
+                        fti.archNm = "addon_d.ipf";
+						fti.fileNm = fPath.Remove(0, dPath.Length == 1 ? 0 : dPath.Length).Replace("\\","/");
 						//Print(fti.archNm + " | " +fti.fileNm);
 						lstFileTab.Add(fti);
 					}
@@ -77,7 +80,8 @@ namespace tpIpfTool {
 
 		public int Packing() {
 			Print("ファイル構成開始");
-			using (FileStream fw = new FileStream(Directory.GetCurrentDirectory()+"/"+"_p"+DateTime.Now.ToString("yyMMddhhmmss")+".ipf", FileMode.CreateNew, FileAccess.ReadWrite)) {
+            string fileName = string.IsNullOrEmpty(ipfTgtName) ? "_p" + DateTime.Now.ToString("yyMMddhhmmss") : ipfTgtName;
+            using (FileStream fw = new FileStream(Directory.GetCurrentDirectory()+"/"+fileName+".ipf", FileMode.Create, FileAccess.ReadWrite)) {
 				foreach (var fti in lstFileTab) {
 					using (FileStream fr = new FileStream(fti.filePath, FileMode.Open, FileAccess.Read)) {
 						IpfCrypt ic = new IpfCrypt();

--- a/tpIpfTool/MainWindow.xaml.cs
+++ b/tpIpfTool/MainWindow.xaml.cs
@@ -25,17 +25,38 @@ namespace tpIpfTool {
 			InitializeComponent();
 			DataContext = mdl;
 			Print("Start");
-			String[] args = App.Args;
-			for (int i=0; i<args.Length; i++) {
-				Print("arg["+i+"]:"+args[i]);
-				modeArgs = true;
+            string commandType = null;
+            String[] args = App.Args;
+            int i = 0;
+            foreach(string arg in App.Args) {
+			//for (int i=0; i<args.Length; i++) {
+                if (!string.IsNullOrEmpty(commandType)) {
+                    if (commandType == "name")
+                    {
+                        trgName = arg;
+                        commandType = null;
+                    }
+                    args[i] = null;
+                }
+                else if (arg.StartsWith("--"))
+                {
+                    commandType = arg.TrimStart('-');
+                    args[i] = null;
+                }
+                else
+                {
+				    modeArgs = true;
+				    Print("arg["+i+"]:"+arg);
+                }
+                i++;
 			}
 			if (modeArgs) {
-				Execute(args);
+				Execute(args.Where(n => n != null).ToArray());
 			}
 		
 		}
 		bool modeArgs = false;
+        string trgName = null;
 		private void Window_PreviewDragOver(object sender, DragEventArgs e) {
 			if (e.Data.GetDataPresent(DataFormats.FileDrop, true)) {
 				e.Effects = DragDropEffects.Copy;
@@ -105,7 +126,7 @@ namespace tpIpfTool {
 			if (modePac && modePacIpf) {
 				Task task = new Task(() => {
 					IpfPack ip = new IpfPack(Print);
-					int ret = ip.PacIpf(files, mdl.tgtver, mdl.pkgver);
+					int ret = ip.PacIpf(files, mdl.tgtver, mdl.pkgver, trgName);
 					if (modeArgs && (ret>-1)) {
 						Environment.Exit(0);
 					}
@@ -116,7 +137,7 @@ namespace tpIpfTool {
 			if (modePac && modePacAddon) {
 				Task task = new Task(() => {
 					IpfPack ip = new IpfPack(Print);
-					int ret = ip.PacAddon(files, mdl.tgtver, mdl.pkgver);
+					int ret = ip.PacAddon(files, mdl.tgtver, mdl.pkgver, trgName);
 					if (modeArgs && (ret>-1)) {
 						Environment.Exit(0);
 					}


### PR DESCRIPTION
`--name` で吐き出すファイル名を指定可能に
fti.fileNmが dPath.Length=1の場合に先頭一文字トリムされる問題の修正